### PR TITLE
Remove createJSModules for RN 0.47.

### DIFF
--- a/android/src/main/java/com/artirigo/kontaktio/KontaktPackage.java
+++ b/android/src/main/java/com/artirigo/kontaktio/KontaktPackage.java
@@ -15,6 +15,10 @@ import java.util.List;
  */
 public class KontaktPackage implements ReactPackage {
 
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();

--- a/android/src/main/java/com/artirigo/kontaktio/KontaktPackage.java
+++ b/android/src/main/java/com/artirigo/kontaktio/KontaktPackage.java
@@ -16,11 +16,6 @@ import java.util.List;
 public class KontaktPackage implements ReactPackage {
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/artirigo/kontaktio/KontaktPackage.java
+++ b/android/src/main/java/com/artirigo/kontaktio/KontaktPackage.java
@@ -15,6 +15,7 @@ import java.util.List;
  */
 public class KontaktPackage implements ReactPackage {
 
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Many react-native libraries removes this method (e.g. https://github.com/Microsoft/react-native-code-push/issues/894).