### PR TITLE
Fix imports for React Native 0.48.x. Close #20

### DIFF
--- a/ios/KontaktBeacons.h
+++ b/ios/KontaktBeacons.h
@@ -1,13 +1,13 @@
-#if __has_include("RCTBridgeModule.h")
-  #import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
   #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
 #endif
 
-#if __has_include("RCTEventEmitter.h")
-  #import "RCTEventEmitter.h"
-#else
+#if __has_include(<React/RCTEventEmitter.h>)
   #import <React/RCTEventEmitter.h>
+#else
+  #import "RCTEventEmitter.h"
 #endif
 
 


### PR DESCRIPTION
This PR fixes #20.
It is inspired from https://github.com/ivpusic/react-native-image-crop-picker/pull/437, https://github.com/Polidea/react-native-ble-plx/pull/136, https://github.com/yonahforst/react-native-permissions/issues/137.

I confirmed this fixed compile errors in my project using RN 0.48.3 and in the reproduction repository mentioned in #20.