### PR TITLE
Fix/is connected behavior

### DIFF
--- a/android/src/main/java/com/artirigo/kontaktio/BeaconProximityManager.java
+++ b/android/src/main/java/com/artirigo/kontaktio/BeaconProximityManager.java
@@ -108,12 +108,8 @@ class BeaconProximityManager {
 
     void isConnected(Promise promise) {
         try {
-            if (proximityManager != null) {
-                boolean isConnected = proximityManager.isConnected();
-                promise.resolve(isConnected);
-            } else {
-                promise.resolve(false);
-            }
+            boolean isConnected = proximityManager.isConnected();
+            promise.resolve(isConnected);
         } catch (Exception e) {
             promise.reject(Constants.EXCEPTION, e);
         }

--- a/android/src/main/java/com/artirigo/kontaktio/Constants.java
+++ b/android/src/main/java/com/artirigo/kontaktio/Constants.java
@@ -2,5 +2,7 @@ package com.artirigo.kontaktio;
 
 public class Constants {
     public static final String EXCEPTION = "JAVA_EXCEPTION";
-    public static final String ERROR = "ERROR";
+    public static final String ERROR = "REACT_NATIVE_KONTAKTIO_ERROR";
+
+    public static final String TAG = "com.artirigo.kontaktio";
 }

--- a/android/src/main/java/com/artirigo/kontaktio/KontaktModule.java
+++ b/android/src/main/java/com/artirigo/kontaktio/KontaktModule.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import android.util.Log;
+
 import static com.artirigo.kontaktio.ReactUtils.sendEvent;
 
 /**
@@ -146,11 +148,11 @@ public class KontaktModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void isConnected(Promise promise) {
-        if (beaconProximityManager != null) {
+        if (beaconProximityManager != null && proximityManager != null) {
             beaconProximityManager.isConnected(promise);
         } else {
-            promise.reject(
-                    "Did you forget to call connect() or did the connect() call fail? The scanManager object is not defined.");
+            Log.w(Constants.TAG, "Did you forget to call connect() or did the connect() call fail? The beaconProximityManager object is not defined.");
+            promise.resolve(false);
         }
     }
 


### PR DESCRIPTION
- In my view the `isConnected` function should ALWAYS return a boolean if the `proximityManager` is not defined. In case an exception comes up when running the internal `isConnection` function, the promise should be rejected with that exception because in this case the `connect` call was successful, but there is something else going on which is worth throwing. 

- `KontaktModule.java` additionally tests whether `proximityManager != null` so that `BeaconProximityManager.java` does not have to check for this anymore. Hence, only exceptions which are not related to manager objects not being initialised are rejected.